### PR TITLE
Do not request container size when listing all containers

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func ContainerAttachThread(c *docker.Client) error {
 	containerAttached := make(map[string]string)
 	containerList := []string{}
 
-	containers, err := c.ListContainers(docker.ListContainersOptions{All: false, Size: true, Limit: 0, Since: "", Before: ""})
+	containers, err := c.ListContainers(docker.ListContainersOptions{All: false, Size: false, Limit: 0, Since: "", Before: ""})
 	if err != nil {
 		log.Println("[CONTAINER ATTACH THREAD ERROR]: Listing Containers failed")
 		return err
@@ -239,7 +239,7 @@ func ContainerAttachThread(c *docker.Client) error {
 				os.Exit(1)
 			}
 
-			containers, err := c.ListContainers(docker.ListContainersOptions{All: false, Size: true, Limit: 0, Since: "", Before: ""})
+			containers, err := c.ListContainers(docker.ListContainersOptions{All: false, Size: false, Limit: 0, Since: "", Before: ""})
 			if err != nil {
 				log.Println("[CONTAINER ATTACH THREAD ERROR]: Listing Containers failed")
 				return err


### PR DESCRIPTION
Requesting container size in ListContainers is an expensive operation.
The list-size operation is blocking the docker daemon from doing other
container list operations (i.e. docker ps`). Even worse, the
network-daemon is also blocked from attaching weave to new containers
during this time. On my setup the list call with size takes over 5
minutes, rendering the entire setup practically useless.

There is absolutely no need for the network-daemon to know the size of
the containers, I do not know why it was set to true in the first place
but it should most definitely not be requested.

Please see further discussion in #3. This PR was created against staging as requested by @MaximeHeckel.
